### PR TITLE
Update to manage to manage new content negociation scheme

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -836,7 +836,9 @@ components:
           type: object
           description: properties extracted from pds4 model, syntax for property name is <namespace>:<property>[/<namespace>:<property>]*
           additionalProperties:
-            type: object
+            type: array
+            items:
+              type: string
             xml:
               prefix: 'pds_api'
               namespace: 'http://pds.nasa.gov/api'

--- a/swagger.yml
+++ b/swagger.yml
@@ -2,13 +2,13 @@ openapi: 3.0.0
 # Added by API Auto Mocking Plugin
 servers:
   - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/PDS_APIs/pds_federated_api/0.1.1
+    url: https://virtserver.swaggerhub.com/PDS_APIs/pds_federated_api/0.1.0
  
 info:
   description: |
     Federated PDS API which provides actionable end points standardized
     between the different nodes.
-  version: 0.2.1
+  version: 0.3.dev
   title: Planetary Data System API
   termsOfService: 'http://pds.nasa.gov'
   contact:
@@ -37,9 +37,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/products'
             application/xml:
-              schema:
-                type: object
-            application/pds4+xml:
               schema:
                 type: object
         '404':
@@ -138,9 +135,6 @@ paths:
             application/xml:
               schema:
                 type: object
-            application/pds4+xml:
-              schema:
-                type: object
         '404':
           description: lidvid not found
         '500':
@@ -203,9 +197,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/products'
             application/xml:
-              schema:
-                type: object
-            application/pds4+xml:
               schema:
                 type: object
         '404':
@@ -275,9 +266,6 @@ paths:
               schema: 
                 $ref: '#/components/schemas/products'
             application/xml:
-              schema:
-                type: object
-            application/pds4+xml:
               schema:
                 type: object
         '400':
@@ -446,9 +434,6 @@ paths:
             application/xml:
               schema:
                 type: object
-            application/pds4+xml:
-              schema:
-                type: object
         '404':
           description: lidvid not found
         '500':
@@ -516,9 +501,6 @@ paths:
               schema: 
                 $ref: '#/components/schemas/products'
             application/xml:
-              schema:
-                type: object
-            application/pds4+xml:
               schema:
                 type: object
         '400':
@@ -620,9 +602,6 @@ paths:
             application/xml:
               schema:
                 type: object
-            application/pds4+xml:
-              schema:
-                type: object
         '404':
           description: lidvid not found
         '500':
@@ -685,9 +664,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/products'
             application/xml:
-              schema:
-                type: object
-            application/pds4+xml:
               schema:
                 type: object
         '404':

--- a/swagger.yml
+++ b/swagger.yml
@@ -836,23 +836,26 @@ components:
           type: object
           description: properties extracted from pds4 model, syntax for property name is <namespace>:<property>[/<namespace>:<property>]*
           additionalProperties:
-            oneOf:
-              - type: array 
-                items:
-                  type: string
-                xml:
-                  prefix: 'pds_api'
-                  namespace: 'http://pds.nasa.gov/api'
-              - type: string
-                xml:
-                  prefix: 'pds_api'
-                  namespace: 'http://pds.nasa.gov/api'
-            xml:
-              prefix: 'pds_api'
-              namespace: 'http://pds.nasa.gov/api'
+            $ref: '#/components/schemas/propertyValue'
           xml:
             prefix: 'pds_api'
             namespace: 'http://pds.nasa.gov/api'
+      xml:
+        prefix: 'pds_api'
+        namespace: 'http://pds.nasa.gov/api'
+    propertyValue:
+      oneOf:
+        - $ref: '#/components/schema/propertyValueArray'
+        - $ref: '#/components/schema/propertyValueString'
+    propertyValueArray:
+      type: array 
+      items:
+        type: string
+      xml:
+        prefix: 'pds_api'
+        namespace: 'http://pds.nasa.gov/api'
+    propertyValueString:
+      type: string
       xml:
         prefix: 'pds_api'
         namespace: 'http://pds.nasa.gov/api'

--- a/swagger.yml
+++ b/swagger.yml
@@ -836,9 +836,17 @@ components:
           type: object
           description: properties extracted from pds4 model, syntax for property name is <namespace>:<property>[/<namespace>:<property>]*
           additionalProperties:
-            type: array
-            items:
-              type: string
+            oneOf:
+              - type: array 
+                items:
+                  type: string
+                xml:
+                  prefix: 'pds_api'
+                  namespace: 'http://pds.nasa.gov/api'
+              - type: string
+                xml:
+                  prefix: 'pds_api'
+                  namespace: 'http://pds.nasa.gov/api'
             xml:
               prefix: 'pds_api'
               namespace: 'http://pds.nasa.gov/api'

--- a/swagger.yml
+++ b/swagger.yml
@@ -810,6 +810,12 @@ components:
           description: properties extracted from pds4 model, syntax for property name is <namespace>:<property>[/<namespace>:<property>]*
           additionalProperties:
             type: object
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
+      xml:
+        prefix: 'pds_api'
+        namespace: 'http://pds.nasa.gov/api'
     reference:
       type: object
       description: object describing a reference to a different product. TODO The properties should be defined by a standard (xlink, json-ld) to be chosen

--- a/swagger.yml
+++ b/swagger.yml
@@ -776,33 +776,60 @@ components:
         id:
           type: string
           description: identifier lidvid of the collection
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         type:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         title:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         description:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         start_date_time:
           type: string
           description: start date time of the observations in ISO8601
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         stop_date_time:
           type: string
           description: stop date time of the observations in ISO8601
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         investigations:
           type: array
           description: list of missions or observing campaigns which produced the data
           items:
             $ref: '#/components/schemas/reference'
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         observing_system_components: 
           type: array
           description: list of instruments or platforms generating the data
           items:
             $ref: '#/components/schemas/reference'
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         targets: 
           type: array
           description: list of targets or feature of interest the observation.
           items:
             $ref: '#/components/schemas/reference'
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         metadata:
           $ref: '#/components/schemas/metadata'
         properties:
@@ -810,6 +837,9 @@ components:
           description: properties extracted from pds4 model, syntax for property name is <namespace>:<property>[/<namespace>:<property>]*
           additionalProperties:
             type: object
+            xml:
+              prefix: 'pds_api'
+              namespace: 'http://pds.nasa.gov/api'
           xml:
             prefix: 'pds_api'
             namespace: 'http://pds.nasa.gov/api'
@@ -825,18 +855,36 @@ components:
         title:
           type: string
           description: name to display for the external reference
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         id:
           type: string
           description: external reference, here lidvid urn
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         href:
           type: string
           description: external reference url of the current reference resolvable by the current API server, http://pds.nasa.gov/api/products/urn:nasa...
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         type:
           type: string
           description: type of the external reference, can be displayed as an icon for example
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         description:
           type: string
           description: longer description for the external reference, can be displayed in a tooltip
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
+      xml:
+        prefix: 'pds_api'
+        namespace: 'http://pds.nasa.gov/api'
     metadata:
       type: object
       required:
@@ -844,12 +892,27 @@ components:
       properties:
         creation_date_time:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         update_date_time:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         version:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         label_url:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
+      xml:
+        prefix: 'pds_api'
+        namespace: 'http://pds.nasa.gov/api'
     errorMessage:
       type: object
       required:
@@ -860,12 +923,27 @@ components:
       properties:
         url:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         resource:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         query:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
         message:
           type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
+      xml:
+        prefix: 'pds_api'
+        namespace: 'http://pds.nasa.gov/api'
       example:
         {
           url: 'https://pds.nasa.gov/api/1.0/collections',

--- a/swagger.yml
+++ b/swagger.yml
@@ -847,9 +847,6 @@ components:
       type: array 
       items:
         type: string
-        xml:
-          prefix: 'pds_api'
-          namespace: 'http://pds.nasa.gov/api'
       xml:
         prefix: 'pds_api'
         namespace: 'http://pds.nasa.gov/api'

--- a/swagger.yml
+++ b/swagger.yml
@@ -847,6 +847,9 @@ components:
       type: array 
       items:
         type: string
+        xml:
+          prefix: 'pds_api'
+          namespace: 'http://pds.nasa.gov/api'
       xml:
         prefix: 'pds_api'
         namespace: 'http://pds.nasa.gov/api'

--- a/swagger.yml
+++ b/swagger.yml
@@ -836,14 +836,14 @@ components:
           type: object
           description: properties extracted from pds4 model, syntax for property name is <namespace>:<property>[/<namespace>:<property>]*
           additionalProperties:
-            $ref: '#/components/schemas/propertyValue'
+            $ref: '#/components/schemas/propertyValues'
           xml:
             prefix: 'pds_api'
             namespace: 'http://pds.nasa.gov/api'
       xml:
         prefix: 'pds_api'
         namespace: 'http://pds.nasa.gov/api'
-    propertyValue:
+    propertyValues:
       type: array 
       items:
         type: string

--- a/swagger.yml
+++ b/swagger.yml
@@ -844,12 +844,20 @@ components:
         prefix: 'pds_api'
         namespace: 'http://pds.nasa.gov/api'
     propertyValues:
-      type: array 
-      items:
-        type: string
+      type: object
+      required:
+        - values
+      properties:
+        values:
+          type: array 
+          items:
+            type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
       xml:
-        prefix: 'pds_api'
-        namespace: 'http://pds.nasa.gov/api'
+          prefix: 'pds_api'
+          namespace: 'http://pds.nasa.gov/api'
     reference:
       type: object
       description: object describing a reference to a different product. TODO The properties should be defined by a standard (xlink, json-ld) to be chosen

--- a/swagger.yml
+++ b/swagger.yml
@@ -844,10 +844,6 @@ components:
         prefix: 'pds_api'
         namespace: 'http://pds.nasa.gov/api'
     propertyValue:
-      oneOf:
-        - $ref: '#/components/schemas/propertyValueArray'
-        - type: string
-    propertyValueArray:
       type: array 
       items:
         type: string

--- a/swagger.yml
+++ b/swagger.yml
@@ -845,17 +845,12 @@ components:
         namespace: 'http://pds.nasa.gov/api'
     propertyValue:
       oneOf:
-        - $ref: '#/components/schema/propertyValueArray'
-        - $ref: '#/components/schema/propertyValueString'
+        - $ref: '#/components/schemas/propertyValueArray'
+        - type: string
     propertyValueArray:
       type: array 
       items:
         type: string
-      xml:
-        prefix: 'pds_api'
-        namespace: 'http://pds.nasa.gov/api'
-    propertyValueString:
-      type: string
       xml:
         prefix: 'pds_api'
         namespace: 'http://pds.nasa.gov/api'


### PR DESCRIPTION
**Summary***
We manage application/json and application/xml canonical map on the API objects.
only application/pds4+xml returns the pds4 label blob.


**Test Data and/or Report**
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

**Related Issues**
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.
-->

        - fixes https://github.com/NASA-PDS/pds-api/issues/80
        - fixes https://github.com/NASA-PDS/registry-api-service/issues/27
        -
